### PR TITLE
Backport empty array handling

### DIFF
--- a/lua_cjson.c
+++ b/lua_cjson.c
@@ -746,7 +746,7 @@ static void json_append_data(lua_State *l, json_config_t *cfg,
         if (has_metatable) {
             // Check if the MT is the empty array
             lua_getmetatable(l, -1);
-            lua_pushlightuserdata(l, (void *)&json_empty_array));
+            lua_pushlightuserdata(l, (void *)&json_empty_array);
             lua_rawget(l, LUA_REGISTRYINDEX);
             as_array = lua_rawequal(l, -1, -2);
             lua_pop(l, 2);


### PR DESCRIPTION
From https://github.com/openresty/lua-cjson:

- add `cjson.encode_empty_table_as_object` to encode all `{}` as empty arrays
- add `cjson. decode_array_with_array_mt` to set `cjson.array_mt` as metatable on decoded arrays
- tables with `cjson.array_mt` as metatable are always written as arrays